### PR TITLE
Parents Manipulation Example

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -16,6 +16,7 @@ object outOfScopeTypeParam            extends DottyModule
 object outOfScopeClassConstructor     extends DottyModule
 object buildingCustomASTs             extends DottyModule
 object contextParamResolution         extends DottyModule
+object newWith                        extends DottyModule
 
 object test extends Module {
   def all = List(

--- a/newWith/src/Test.scala
+++ b/newWith/src/Test.scala
@@ -1,0 +1,15 @@
+class Base:
+  def say() = println(value)
+  def value = "World"
+
+trait Foo:
+  this: Base =>
+  override def value = "Me"
+
+trait Bar:
+  this: Base =>
+  override def value = "Stuff"
+
+@main def Test =
+  val instance = mcr[Bar]
+  instance.say()

--- a/newWith/src/macro.scala
+++ b/newWith/src/macro.scala
@@ -1,0 +1,32 @@
+import scala.quoted.*
+
+inline def mcr[T]: Base = ${ mcrImpl[T] }
+def mcrImpl[T: Type](using Quotes): Expr[Base] =
+  import quotes.reflect.*
+
+  class MyTreeMap extends TreeMap:
+    override def transformStatement(tree: Statement)(owner: Symbol): Statement =
+      println(s"Traversing tree ${tree.getClass}")
+      tree match
+        case t@ClassDef(name, constr, parents, selfOpt, body) =>
+          ClassDef.copy(t)(name, constr, parents :+ TypeTree.of[T], selfOpt, body)
+        case _ =>
+          super.transformStatement(tree)(owner)
+
+    override def transformTerm(tree: Term)(owner: Symbol): Term =
+      tree match
+        case Typed(expr, tpt) =>
+          val newTpe = tpt.tpe match
+            case t@AndType(base, foo) => AndType(t, TypeTree.of[T].tpe)
+          val newTpt = Inferred(newTpe)
+          Typed(expr, newTpt)
+        case _ =>
+          super.transformTerm(tree)(owner)
+  end MyTreeMap
+
+  val expr = '{new Base with Foo}
+  val newTree = new MyTreeMap().transformTree(expr.asTerm)(Symbol.spliceOwner)
+  val newExpr = newTree.asExpr
+  println(newExpr.show)
+  println(newTree.show(using Printer.TreeStructure))
+  newExpr.asExprOf[Base]


### PR DESCRIPTION
The idea is:

- We have an expression `new Base with Foo` in a macro
- We would like to make it into `new Base with Foo with T`, where `T` is passed as a type parameter to the macro by the user

An expression `new Base with Foo` is desugared to the following block:

```scala
{
  final class $anon() extends Base with Foo

  (new $anon(): Base & Foo)
}
```

If we want `new Base with Foo with T`, we aim to create the following block:

```scala
{
  final class $anon() extends Base with Foo with T

  (new $anon(): Base & Foo & T)
}
```

Parents, `Foo` and `Bar`, live in a `Template` node for which there is no reflect API.

<details><summary>AST of the $anon class</summary>

```scala
      TypeDef(
        $anon,
        Template(
          DefDef(
            <init>,
            List(
              List(
                
              )
            ),
            TypeTree[
              TypeRef(
                TermRef(
                  ThisType(
                    TypeRef(
                      NoPrefix,
                      module class <root>
                    )
                  ),
                  object scala
                ),
                Unit
              )
            ],
            EmptyTree
          ),
          List(
            Apply(
              Select(
                New(
                  Ident(
                    Base
                  )
                ),
                <init>
              ),
              List(
                
              )
            ),
             Ident(
              Foo
            ),
             TypeTree[
              TypeRef(
                ThisType(
                  TypeRef(
                    NoPrefix,
                    module class <empty>
                  )
                ),
                trait Bar
              )
            ]
          ),
          ValDef(
            _,
            EmptyTree,
            EmptyTree
          ),
          List(
            
          )
        )
      )
```
</details>

This PR adopts a hacky solution. To add `T` as a parent to `new Base with Foo`, we start with an expression `'{new Base with Foo}`. We then use `TreeMap` to detect the `Template` node, break the interface and use the compiler internals to copy it with `T` as an injected parent. We then use a similar approach to transform `(new $anon(): Base & Foo)`, the last statement of the block showcased above, into `(new $anon(): Base & Foo & T)`.

However, even though the ASTs produced appear to be correct, it appears that the expression is compiled as if it is still `new Base with Foo`. That is, in the test case from the PR, the override from `Bar` is not visible.

@nicolasstucki is there a cleaner approach to solve this problem? Why does the hacky AST not work? And why there's no API for template manipulation?