### PR TITLE
Update default value example

### DIFF
--- a/defaultParamsInference/src/macro.scala
+++ b/defaultParamsInference/src/macro.scala
@@ -8,6 +8,7 @@ def defaultParmasImpl[T](using quotes: Quotes, tpe: Type[T]): Expr[Map[String, A
   import quotes.reflect.*
   val sym = TypeTree.of[T].symbol
   val comp = sym.companionClass
+  val mod = Ref(sym.companionModule)
   val names =
     for p <- sym.caseFields if p.flags.is(Flags.HasDefault)
     yield p.name
@@ -18,7 +19,7 @@ def defaultParmasImpl[T](using quotes: Quotes, tpe: Type[T]): Expr[Map[String, A
   val idents: List[Ref] =
     for case deff @ DefDef(name, _, _, _) <- body
     if name.startsWith("$lessinit$greater$default")
-    yield Ref(deff.symbol)
+    yield mod.select(deff.symbol)
   val identsExpr: Expr[List[Any]] =
     Expr.ofList(idents.map(_.asExpr))
 


### PR DESCRIPTION
In some case a direct `Ref` for on a default value symbol will fail; e.g.

```
...

exception while typing Product.this of class class dotty.tools.dotc.ast.Trees$This # -1
exception while typing Product.this.$lessinit$greater$default$4 of class class dotty.tools.dotc.ast.Trees$Select # -1
exception while typing Product.this.$lessinit$greater$default$4 of class class dotty.tools.dotc.ast.Trees$Inlined # -1
exception while typing val x: Option[Int] = Product.this.$lessinit$greater$default$4 of class class dotty.tools.dotc.ast.Trees$ValDef # -1
exception while typing {
  val x: Option[Int] = Product.this.$lessinit$greater$default$4

...

[error] java.lang.AssertionError: assertion failed: asTerm called on not-a-Term val <none>
[error] scala.runtime.Scala3RunTime$.assertFailed(Scala3RunTime.scala:8)
[error] dotty.tools.dotc.core.Symbols$Symbol.asTerm(Symbols.scala:163)
[error] dotty.tools.dotc.transform.ExplicitOuter$.dotty$tools$dotc$transform$ExplicitOuter$$$outerParamAccessor(ExplicitOuter.scala:228)
[error] dotty.tools.dotc.transform.ExplicitOuter$OuterOps$.loop$1(ExplicitOuter.scala:429)
[error] dotty.tools.dotc.transform.ExplicitOuter$OuterOps$.path$extension(ExplicitOuter.scala:438)
[error] dotty.tools.dotc.transform.Erasure$Typer.typedThis(Erasure.scala:774)
[error] dotty.tools.dotc.typer.Typer.typedUnnamed$1(Typer.scala:2803)
[error] dotty.tools.dotc.typer.Typer.typedUnadapted(Typer.scala:2865)
[error] dotty.tools.dotc.typer.ReTyper.typedUnadapted(ReTyper.scala:121)
```