### PR TITLE
Add a demo porting for the scala-sql project to Scala3

### DIFF
--- a/accessEnclosingParameters/src/calleeParamRefs.scala
+++ b/accessEnclosingParameters/src/calleeParamRefs.scala
@@ -2,7 +2,7 @@ package macros
 
 import scala.quoted.*
 
-def calleeParamRefs(using Quotes)(callee: quotes.reflect.Symbol): List[List[quotes.reflect.Term]] =
+def calleeParamRefs(using quotes: Quotes)(callee: quotes.reflect.Symbol): List[List[quotes.reflect.Term]] =
   import quotes.reflect.*
   val termParamss = callee.paramSymss.filterNot(_.headOption.exists(_.isType))
   termParamss.map(_.map(Ref.apply))

--- a/build.sbt
+++ b/build.sbt
@@ -21,4 +21,7 @@ lazy val contextParamResolution = DottyProject("contextParamResolution")
 lazy val passVarargsIntoAST = DottyProject("passVarargsIntoAST")
 lazy val primaryConstructor = DottyProject("primaryConstructor")
 lazy val referenceVariableFromOtherExpr = DottyProject("referenceVariableFromOtherExpr")
+lazy val inlineDemo = DottyProject("inlineDemo")
+lazy val logAST = DottyProject("logAST")
+lazy val symbolTest = DottyProject("symbolTest").dependsOn(logAST)
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,7 @@ def DottyProject(name: String): Project =
   Project.apply(name, file(name)).settings(
     scalaVersion := "3.1.0",
     Compile / scalaSource := baseDirectory.value / "src",
+    libraryDependencies += "org.scala-lang" %% "scala3-compiler" % scalaVersion.value,
   )
 
 lazy val abstractTypeclassBody = DottyProject("abstractTypeclassBody")
@@ -21,9 +22,10 @@ lazy val contextParamResolution = DottyProject("contextParamResolution")
 lazy val passVarargsIntoAST = DottyProject("passVarargsIntoAST")
 lazy val primaryConstructor = DottyProject("primaryConstructor")
 lazy val referenceVariableFromOtherExpr = DottyProject("referenceVariableFromOtherExpr")
-lazy val reflectionLambda = DottyProject("referenceVariableFromOtherExpr")
+lazy val reflectionLambda = DottyProject("reflectionLambda")
 
 lazy val inlineDemo = DottyProject("inlineDemo")
 lazy val logAST = DottyProject("logAST")
 lazy val symbolTest = DottyProject("symbolTest").dependsOn(logAST)
+lazy val sqlDemo = DottyProject("sqlDemo")
 

--- a/inlineDemo/readme.md
+++ b/inlineDemo/readme.md
@@ -1,0 +1,3 @@
+This demo comes from [scala3-macros](https://github.com/plewand/scala3-macros/blob/master/src/main/scala/scalamacros/logast/LogAST.scala)
+
+1. the `summonInline[T]` may works in the inlined context, not the definition context.

--- a/inlineDemo/src/InlineDemo.scala
+++ b/inlineDemo/src/InlineDemo.scala
@@ -1,0 +1,34 @@
+package dummy
+
+import scala.compiletime.summonInline
+
+object Inlines {
+  given context:String = "definition"
+
+  inline def f(inline p: Int) = {
+    val ctx = summonInline[String]      // search in inline-context
+    println(s"Inline1: parameter: $p, given $ctx")
+    println(s"Inline2: parameter: $p, given $ctx")
+  }
+
+  def g(p: Int) = {
+    val ctx = summonInline[String]    // search in g's context
+    println(s"Regular1: parameter: $p, given $ctx")
+    println(s"Regular2: parameter: $p, given $ctx")
+  }
+}
+
+@main() def inlineTest() = {
+  import Inlines.*
+
+  given context:String = "usage"
+
+  var a = 1;
+  def sideEffect() : Int = {
+    a += 1
+    a
+  }
+  val b = 2;
+  f(sideEffect())
+  g(sideEffect())
+}

--- a/logAST/readme.md
+++ b/logAST/readme.md
@@ -1,0 +1,1 @@
+This demo comes from [scala3-macros](https://github.com/plewand/scala3-macros/blob/master/src/main/scala/scalamacros/logast/LogAST.scala)

--- a/logAST/src/LogAST.scala
+++ b/logAST/src/LogAST.scala
@@ -1,0 +1,23 @@
+package dummy
+
+import scala.quoted.*
+
+// Macro entry point - an inline function. The argument needs to be also inlined to get
+// the information about AST of the code that should be printed not its reference.
+inline def logAST[T](inline expression: T) = ${ logASTImpl('expression) }
+
+// An utility to print generic code, both AST and the code itself.
+// Useful when creating/matching AST in own macros to see how the
+// valid code looks as AST.
+def logASTImpl[T: Type](expression: Expr[T])(using q: Quotes) : Expr[T]= {
+  import quotes.reflect.*
+  val term = expression.asTerm
+  println(s"===========Tree of type ${Type.show}=========:")
+  println("TreeAnsiCode")
+  println(term.show(using Printer.TreeAnsiCode))
+  println("TreeStructure")
+  println(term.show(using Printer.TreeStructure))
+  println()
+  println("===========================")
+  expression
+}

--- a/logAST/src/Test.scala
+++ b/logAST/src/Test.scala
@@ -1,0 +1,13 @@
+package dummy
+
+@main def logASTTest(): Unit = {
+
+  class A
+
+  // Logged AST that was used to find out the structure of the code that was matched in the macro.
+  val a: A = logAST {
+    System.out.println("inside block")
+
+    new A
+  }
+}

--- a/sqlDemo/README.md
+++ b/sqlDemo/README.md
@@ -1,0 +1,5 @@
+# A Demo Porting for scala-sql's macro into scala3
+
+- `{$x: t}` extract the type of expr `x` and continue to expand the macro.
+- `Expr.summon` search the implicit value
+- using tasty reflection to create the method tree

--- a/sqlDemo/src/Demo.scala
+++ b/sqlDemo/src/Demo.scala
@@ -1,0 +1,14 @@
+package dummy
+
+import ScalaSql.*
+import SqlMacro.*
+
+case class Order(
+                orderNo: Int,
+                orderDate: String,
+                orderTime: String,
+                amount: Int
+                )
+
+@main
+def test: ResultSetMapper[Order] = resultSetMapper[Order]

--- a/sqlDemo/src/ScalaSql.scala
+++ b/sqlDemo/src/ScalaSql.scala
@@ -1,0 +1,92 @@
+package dummy
+
+import java.sql.*
+import scala.quoted.*
+
+/**
+ * ScalaSql is a demo-porting of the [scala-sql](https://github.com/wangzaixiang/scala-sql) project into Scala3.
+ */
+object ScalaSql:
+  trait ResultSetMapper[T]:
+    def from(rs: ResultSet): T
+
+  trait JdbcAccessor[T]:
+    def get(rs: ResultSet, name: String): T
+
+  extension (rs: ResultSet)
+    def get[T: JdbcAccessor](name: String): T =
+      summon[JdbcAccessor[T]].get(rs, name)
+
+  given JdbcAccessor[String] with
+    def get(rs: ResultSet, name: String): String =
+      rs.getString(name)
+
+  given JdbcAccessor[Int] with
+    def get(rs: ResultSet, name: String): Int =
+      rs.getInt(name)
+
+object SqlMacro:
+  import ScalaSql.{given, *}
+
+  inline def resultSetMapper[T]: ResultSetMapper[T] = ${ rsMapperImpl[T] }
+
+  private def rsMapperImpl[T: Type](using Quotes): Expr[ResultSetMapper[T]] = {
+    import quotes.reflect.*
+
+    def exprForField[T: Type](field: Symbol)(using Quotes): Expr[?] =
+      val typetree = TypeTree.of[T]
+      val nullObj = Typed(Literal(NullConstant()), typetree)
+      val fieldTypeTree = field.tree.asInstanceOf[ValDef].tpt
+      Typed( Select.unique (nullObj, field.name), fieldTypeTree).asExpr
+
+    def rsGetField[T:Type](rs: Expr[ResultSet], field: Symbol)(using quotes: Quotes): (Symbol, ValDef) =
+      val name = field.name
+      val nameExpr = Expr(name)
+      val tree = field.tree
+      val tpe: TypeRepr =  tree.asInstanceOf[ValDef].tpt.tpe
+
+      val expr = exprForField[T](field)
+
+      val rsGet = expr match {
+        case '{ $x: t } =>
+          val typet = TypeTree.of[t]
+          Expr.summon[JdbcAccessor[t]] match {
+            case Some(accessor) =>
+              '{ $rs.get[t]($nameExpr)(using $accessor) }
+            case None =>
+              ??? // scala.compiletime.error("No JdbcAccessor for type ")
+          }
+      }
+
+      val variable = Symbol.newVal(Symbol.spliceOwner, name, tpe, Flags.EmptyFlags, Symbol.noSymbol)
+      val valdef = ValDef(variable, Some(rsGet.asTerm))
+      (variable, valdef)
+
+
+    def buildBeanFromRs(rs: Expr[ResultSet]) = {
+
+      val tpeSym = TypeTree.of[T].symbol
+      val children = tpeSym.caseFields
+
+      val varsAndDefs: List[(Symbol, ValDef)] = children.map(rsGetField[T](rs, _))
+
+      val companion = tpeSym.companionModule
+      val applyMethod = companion.memberMethod("apply").apply(0)
+
+      val args: List[Ref] = varsAndDefs.map(x => Ref(x._1))
+      val stmts: List[ValDef] = varsAndDefs.map(x => x._2)
+
+      val apply = Apply(
+        Select( Ref(companion), applyMethod),
+        args )
+
+      val block = Block(stmts, apply)
+      block.asExpr.asInstanceOf[Expr[T]]
+    }
+
+    '{
+      new ResultSetMapper[T]:
+        def from(rs: ResultSet): T = ${buildBeanFromRs('{rs})}
+    }
+
+  }

--- a/symbolTest/src/SymbolMacro.scala
+++ b/symbolTest/src/SymbolMacro.scala
@@ -1,0 +1,40 @@
+package dummy
+
+import scala.quoted.*
+
+// Example to use symbols.
+object Symbols {
+
+  def printSymbolsImpl(using q: Quotes) : Expr[Function0[Unit]] = {
+    import quotes.reflect._
+
+    val owner = Expr(Symbol.spliceOwner.name)
+    val parent = Expr(Symbol.spliceOwner.owner.name)
+    val grandParent = Expr(Symbol.spliceOwner.owner.owner.name)
+
+    // The body of the function can be created with quoting and splicing.
+    // It can be also created with use of reflection module.
+    val functionBody: Expr[Unit] = '{
+    println(s"Splice owner: ${$owner}, parent ${$parent}, grandParent ${$grandParent}")
+    }
+
+    // To create a new method Symbol function is used.
+    val functionDefSymbol = Symbol.newMethod(
+      Symbol.spliceOwner,  //Symbol - owner of the method
+      "printSymbolsGenerated",  // The name of the function
+      MethodType(Nil)( // Argument names - in this case empty list
+        _ => Nil, // Argument definitions - in this case empty list
+        _ => TypeRepr.of[Unit] // Return type
+      )
+    )
+
+    // The definition of the function.
+    val functionDef = DefDef(functionDefSymbol, { case _ => Some(functionBody.asTerm.changeOwner(functionDefSymbol)) })
+
+    // The DefDef will not evaluate to Expr (call to isExpr of this term returns false) so it needs to be
+    // included into the AST below. It was found with use of logAST on an empty function.
+    Block(List(functionDef), Closure(Ref(functionDefSymbol), None)).asExprOf[Function0[Unit]]
+  }
+
+  inline def printSymbols() : Function0[Unit] = ${ printSymbolsImpl }
+}

--- a/symbolTest/src/Test.scala
+++ b/symbolTest/src/Test.scala
@@ -1,0 +1,20 @@
+package dummy
+
+import dummy.logAST
+
+@main def symbolTest() = {
+
+  def printSymbols: () => Unit = Symbols.printSymbols()
+
+  // It will print: Splice owner: macro, parent printSymbols, grandParent symbolTest
+  printSymbols()
+
+  // To find how the function definition should be constructed in the macro.
+  logAST {
+    // Splice owner: macro parent symbolTest, grandParent Test$package$
+    Symbols.printSymbols()
+    def f() = {
+
+    }
+  }
+}


### PR DESCRIPTION
[scala-sql](https://github.com/wangzaixiang/scala-sql) is a JDBC access framework. It use macro to generate ResultSet Mapper, Bean Builder etc. 

eg. the ResultSetMapper[T] enables read data from ResultSet into Case class

```scala
case class Order(
                orderNo: Int,
                orderDate: String,
                orderTime: String,
                amount: Int
                )
def test: ResultSetMapper[Order] = resultSetMapper[Order] 
```

will expand to 

```
{
  final class $anon() extends proto.Proto.ResultSetMapper[proto.Order] {
    def from(rs: java.sql.ResultSet): proto.Order = {
      val orderNo: scala.Int = proto.Proto.get(rs)[scala.Int]("orderNo")(proto.Proto.given_JdbcAccessor_Int)
      val orderDate: scala.Predef.String = proto.Proto.get(rs)[java.lang.String]("orderDate")(proto.Proto.given_JdbcAccessor_String)
      val orderTime: scala.Predef.String = proto.Proto.get(rs)[java.lang.String]("orderTime")(proto.Proto.given_JdbcAccessor_String)
      val amount: scala.Int = proto.Proto.get(rs)[scala.Int]("amount")(proto.Proto.given_JdbcAccessor_Int)
      proto.Order.apply(orderNo, orderDate, orderTime, amount)
    }
  }

  (new $anon(): proto.Proto.ResultSetMapper[proto.Order])
}
```